### PR TITLE
vendor_spark: Don't enforce inclusion of common compatibility matrix

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -162,8 +162,6 @@ PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += vendor/spark/overlay/common
 
 DEVICE_PACKAGE_OVERLAYS += vendor/spark/overlay/common
 
-DEVICE_FRAMEWORK_COMPATIBILITY_MATRIX_FILE += vendor/spark/config/device_framework_matrix.xml
-
 include packages/overlays/Themes/themes.mk
 
 # Cutout control overlays


### PR DESCRIPTION
* Let people include it if they choose to.
* Avoids issues where people who previously didn't need
  compatibility matrix's are hitting checkvintf errors.

* Fixes breakage in: 78870c267fa57b3cb98607c0715504e6821fd7b6

Change-Id: I33bc1e67e7f9eb9a01930113535800a8e4f539fd