### PR TITLE
Allow a device to manually override which HALs it wants…

### DIFF
--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -124,6 +124,11 @@ else
     QCOM_HARDWARE_VARIANT := $(TARGET_BOARD_PLATFORM)
 endif
 
+# Allow a device to manually override which HALs it wants to use
+ifneq ($(OVERRIDE_QCOM_HARDWARE_VARIANT),)
+QCOM_HARDWARE_VARIANT := $(OVERRIDE_QCOM_HARDWARE_VARIANT)
+endif
+
 # Allow a device to opt-out hardset of PRODUCT_SOONG_NAMESPACES
 QCOM_SOONG_NAMESPACE ?= hardware/qcom-caf/$(QCOM_HARDWARE_VARIANT)
 PRODUCT_SOONG_NAMESPACES += $(QCOM_SOONG_NAMESPACE)


### PR DESCRIPTION
Like for an example: Redmi Note 7 (lavender) is actually msm8998, its community built 4.14 / 4.19 kernels which needs custom msm8998 HALs for proper functionality.
This is done by adding the following line in your Tree:
OVERRIDE_QCOM_HARDWARE_VARIANT := $HALS_PATH

Change-Id: Icf26be96facad5638abd5fb269c41f4e852c16a9

Co-authored-by: Akhil Narang <akhilnarang.1999@gmail.com>