### PR TITLE
Bring back support for NO_KERNEL_OVERRIDE build flag

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -68,6 +68,7 @@
 #                                          modules in vendor_overlay instead of vendor
 
 ifneq ($(TARGET_NO_KERNEL),true)
+ifneq ($(TARGET_NO_KERNEL_OVERRIDE),true)
 
 ## Externally influenced variables
 KERNEL_SRC := $(TARGET_KERNEL_SOURCE)
@@ -545,4 +546,5 @@ dtboimage: $(INSTALLED_DTBOIMAGE_TARGET)
 .PHONY: dtbimage
 dtbimage: $(INSTALLED_DTBIMAGE_TARGET)
 
+endif # TARGET_NO_KERNEL_OVERRIDE
 endif # TARGET_NO_KERNEL

--- a/config/fonts.mk
+++ b/config/fonts.mk
@@ -13,4 +13,34 @@ PRODUCT_PACKAGES += \
     FontOnePlusSansOverlay \
     FontOneplusSlateSourceOverlay \
     FontOneUISansOverlay \
-    FontCustomOverlay
+    FontCustomOverlay \
+    FontAccuratistOverlay \
+    FontAclonicaOverlay \
+    FontAmaranteOverlay \
+    FontBariolOverlay \
+    FontCagliostroOverlay \
+    FontCoconOverlay \
+    FontComfortaaOverlay \
+    FontComicSansOverlay \
+    FontCoolstoryOverlay \
+    FontExotwoOverlay \
+    FontFifa2018Overlay \
+    FontGrandHotelOverlay \
+    FontHarmonySansOverlay \
+    FontLatoOverlay \
+    FontLGSmartGothicOverlay \
+    FontLinotteOverlay \
+    FontNokiaPureOverlay \
+    FontNunitoOverlay \
+    FontOswaldOverlay \
+    FontQuandoOverlay \
+    FontRedressedOverlay \
+    FontReemKufiOverlay \
+    FontRobotoCondensedOverlay \
+    FontRosemaryOverlay \
+    FontRubikOverlay \
+    FontSamsungOneOverlay \
+    FontSonySketchOverlay \
+    FontStoropiaOverlay \
+    FontSurferOverlay \
+    FontUbuntuOverlay

--- a/fonts/FontAccuratistOverlay/Android.bp
+++ b/fonts/FontAccuratistOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontAccuratistOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontAccuratist",
+}

--- a/fonts/FontAccuratistOverlay/AndroidManifest.xml
+++ b/fonts/FontAccuratistOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.accuratist"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_accuratist_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="accuratist,accuratist-semi-bold,accuratist-bold,accuratist-light,accuratist-medium" />
+    </application>
+</manifest>

--- a/fonts/FontAccuratistOverlay/res/values/config.xml
+++ b/fonts/FontAccuratistOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">accuratist</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">accuratist-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">accuratist-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">accuratist-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">accuratist-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontAccuratistOverlay/res/values/strings.xml
+++ b/fonts/FontAccuratistOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Accuratist overlay -->
+    <string name="font_accuratist_overlay" translatable="false">Accuratist</string>
+</resources>

--- a/fonts/FontAclonicaOverlay/Android.bp
+++ b/fonts/FontAclonicaOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontAclonicaOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontAclonica",
+}

--- a/fonts/FontAclonicaOverlay/AndroidManifest.xml
+++ b/fonts/FontAclonicaOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.aclonica"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_aclonica_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="aclonica,aclonica-semi-bold,aclonica-bold" />
+    </application>
+</manifest>

--- a/fonts/FontAclonicaOverlay/res/values/config.xml
+++ b/fonts/FontAclonicaOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">aclonica</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">aclonica-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">aclonica</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">aclonica-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontAclonicaOverlay/res/values/strings.xml
+++ b/fonts/FontAclonicaOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Aclonica overlay -->
+    <string name="font_aclonica_overlay" translatable="false">Aclonica</string>
+</resources>

--- a/fonts/FontAmaranteOverlay/Android.bp
+++ b/fonts/FontAmaranteOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontAmaranteOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontAmarante",
+}

--- a/fonts/FontAmaranteOverlay/AndroidManifest.xml
+++ b/fonts/FontAmaranteOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.amarante"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_amarante_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="amarante,amarante-semi-bold,amarante-bold" />
+    </application>
+</manifest>

--- a/fonts/FontAmaranteOverlay/res/values/config.xml
+++ b/fonts/FontAmaranteOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">amarante</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">amarante-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">amarante</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">amarante-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontAmaranteOverlay/res/values/strings.xml
+++ b/fonts/FontAmaranteOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Amarante overlay -->
+    <string name="font_amarante_overlay" translatable="false">Amarante</string>
+</resources>

--- a/fonts/FontBariolOverlay/Android.bp
+++ b/fonts/FontBariolOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontBariolOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontBariol",
+}

--- a/fonts/FontBariolOverlay/AndroidManifest.xml
+++ b/fonts/FontBariolOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.bariol"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_bariol_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="bariol,bariol-semi-bold,bariol-bold" />
+    </application>
+</manifest>

--- a/fonts/FontBariolOverlay/res/values/config.xml
+++ b/fonts/FontBariolOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">bariol</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">bariol-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">bariol</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">bariol-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontBariolOverlay/res/values/strings.xml
+++ b/fonts/FontBariolOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Bariol overlay -->
+    <string name="font_bariol_overlay" translatable="false">Bariol</string>
+</resources>

--- a/fonts/FontCagliostroOverlay/Android.bp
+++ b/fonts/FontCagliostroOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontCagliostroOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontCagliostro",
+}

--- a/fonts/FontCagliostroOverlay/AndroidManifest.xml
+++ b/fonts/FontCagliostroOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.cagliostro"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_cagliostro_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="cagliostro,cagliostro-semi-bold,cagliostro-bold" />
+    </application>
+</manifest>

--- a/fonts/FontCagliostroOverlay/res/values/config.xml
+++ b/fonts/FontCagliostroOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">cagliostro</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">cagliostro-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">cagliostro</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">cagliostro-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontCagliostroOverlay/res/values/strings.xml
+++ b/fonts/FontCagliostroOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Cagliostro overlay -->
+    <string name="font_cagliostro_overlay" translatable="false">Cagliostro</string>
+</resources>

--- a/fonts/FontCoconOverlay/Android.bp
+++ b/fonts/FontCoconOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontCoconOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontCocon",
+}

--- a/fonts/FontCoconOverlay/AndroidManifest.xml
+++ b/fonts/FontCoconOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.cocon"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_cocon_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="cocon,cocon-semi-bold,cocon-bold,cocon-light,cocon-medium" />
+    </application>
+</manifest>

--- a/fonts/FontCoconOverlay/res/values/config.xml
+++ b/fonts/FontCoconOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">cocon</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">cocon-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">cocon-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">cocon-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">cocon-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontCoconOverlay/res/values/strings.xml
+++ b/fonts/FontCoconOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Cocon overlay -->
+    <string name="font_cocon_overlay" translatable="false">Cocon</string>
+</resources>

--- a/fonts/FontComfortaaOverlay/Android.bp
+++ b/fonts/FontComfortaaOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontComfortaaOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontComfortaa",
+}

--- a/fonts/FontComfortaaOverlay/AndroidManifest.xml
+++ b/fonts/FontComfortaaOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.comfortaa"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_comfortaa_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="comfortaa,comfortaa-medium,comfortaa-semi-bold,comfortaa-bold" />
+    </application>
+</manifest>

--- a/fonts/FontComfortaaOverlay/res/values/config.xml
+++ b/fonts/FontComfortaaOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">comfortaa</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">comfortaa-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">comfortaa-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">comfortaa-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontComfortaaOverlay/res/values/strings.xml
+++ b/fonts/FontComfortaaOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Comfortaa overlay -->
+    <string name="font_comfortaa_overlay" translatable="false">Comfortaa</string>
+</resources>

--- a/fonts/FontComicSansOverlay/Android.bp
+++ b/fonts/FontComicSansOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontComicSansOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontComicSans",
+}

--- a/fonts/FontComicSansOverlay/AndroidManifest.xml
+++ b/fonts/FontComicSansOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.comicsans"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_comicsans_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="comicsans,comicsans-semi-bold,comicsans-bold" />
+    </application>
+</manifest>

--- a/fonts/FontComicSansOverlay/res/values/config.xml
+++ b/fonts/FontComicSansOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">comicsans</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">comicsans-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">comicsans</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">comicsans-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontComicSansOverlay/res/values/strings.xml
+++ b/fonts/FontComicSansOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Comic Sans overlay -->
+    <string name="font_comicsans_overlay" translatable="false">Comic Sans</string>
+</resources>

--- a/fonts/FontCoolstoryOverlay/Android.bp
+++ b/fonts/FontCoolstoryOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontCoolstoryOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontCoolstory",
+}

--- a/fonts/FontCoolstoryOverlay/AndroidManifest.xml
+++ b/fonts/FontCoolstoryOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.coolstory"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_coolstory_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="coolstory,coolstory-semi-bold,coolstory-bold" />
+    </application>
+</manifest>

--- a/fonts/FontCoolstoryOverlay/res/values/config.xml
+++ b/fonts/FontCoolstoryOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">coolstory</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">coolstory-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">coolstory</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">coolstory-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontCoolstoryOverlay/res/values/strings.xml
+++ b/fonts/FontCoolstoryOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Coolstory overlay -->
+    <string name="font_coolstory_overlay" translatable="false">Coolstory</string>
+</resources>

--- a/fonts/FontExotwoOverlay/Android.bp
+++ b/fonts/FontExotwoOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontExotwoOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontExotwo",
+}

--- a/fonts/FontExotwoOverlay/AndroidManifest.xml
+++ b/fonts/FontExotwoOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.exotwo"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_exotwo_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="exotwo,exotwo-medium,exotwo-semi-bold,exotwo-bold" />
+    </application>
+</manifest>

--- a/fonts/FontExotwoOverlay/res/values/config.xml
+++ b/fonts/FontExotwoOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">exotwo</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">exotwo-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">exotwo-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">exotwo-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontExotwoOverlay/res/values/strings.xml
+++ b/fonts/FontExotwoOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font exotwo overlay -->
+    <string name="font_exotwo_overlay" translatable="false">ExoTwo</string>
+</resources>

--- a/fonts/FontFifa2018Overlay/Android.bp
+++ b/fonts/FontFifa2018Overlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontFifa2018Overlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontFifa2018",
+}

--- a/fonts/FontFifa2018Overlay/AndroidManifest.xml
+++ b/fonts/FontFifa2018Overlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.fifa2018"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_fifa2018_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="fifa2018,fifa2018-semi-bold,fifa2018-bold,fifa2018-light,fifa2018-medium" />
+    </application>
+</manifest>

--- a/fonts/FontFifa2018Overlay/res/values/config.xml
+++ b/fonts/FontFifa2018Overlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">fifa2018</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">fifa2018-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">fifa2018-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">fifa2018-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">fifa2018-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontFifa2018Overlay/res/values/strings.xml
+++ b/fonts/FontFifa2018Overlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Fifa 2018 overlay -->
+    <string name="font_fifa2018_overlay" translatable="false">Fifa 2018</string>
+</resources>

--- a/fonts/FontGoogleSansOverlay/Android.bp
+++ b/fonts/FontGoogleSansOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontGoogleSansOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontGoogleSans",
+}

--- a/fonts/FontGoogleSansOverlay/AndroidManifest.xml
+++ b/fonts/FontGoogleSansOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.googlesans"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_googlesans_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="googlesans,googlesans-medium,googlesans-semi-bold,googlesans-bold,googlesans-light,googlesans-regular" />
+    </application>
+</manifest>

--- a/fonts/FontGoogleSansOverlay/res/values/config.xml
+++ b/fonts/FontGoogleSansOverlay/res/values/config.xml
@@ -1,0 +1,33 @@
+<!--
+/**
+ * Copyright (c) 2019-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">googlesans</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">googlesans-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">googlesans-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">googlesans-bold</string>
+    <!-- Allows setting custom fontFeatureSettings on specific text. -->
+    <string name="config_headlineFontFeatureSettings">ss03</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">googlesans-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">googlesans-regular</string>
+</resources>

--- a/fonts/FontGoogleSansOverlay/res/values/strings.xml
+++ b/fonts/FontGoogleSansOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Google Sans overlay -->
+    <string name="font_googlesans_overlay" translatable="false">Google Sans</string>
+</resources>

--- a/fonts/FontGrandHotelOverlay/Android.bp
+++ b/fonts/FontGrandHotelOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontGrandHotelOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontGrandHotel",
+}

--- a/fonts/FontGrandHotelOverlay/AndroidManifest.xml
+++ b/fonts/FontGrandHotelOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.grandhotel"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_grandhotel_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="grandhotel,grandhotel-semi-bold,grandhotel-bold,grandhotel-light,grandhotel-medium" />
+    </application>
+</manifest>

--- a/fonts/FontGrandHotelOverlay/res/values/config.xml
+++ b/fonts/FontGrandHotelOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">grandhotel</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">grandhotel-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">grandhotel-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">grandhotel-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">grandhotel-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontGrandHotelOverlay/res/values/strings.xml
+++ b/fonts/FontGrandHotelOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font GrandHotel overlay -->
+    <string name="font_grandhotel_overlay" translatable="false">grandhotel</string>
+</resources>

--- a/fonts/FontLGSmartGothicOverlay/Android.bp
+++ b/fonts/FontLGSmartGothicOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontLGSmartGothicOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontLGSmartGothic",
+}

--- a/fonts/FontLGSmartGothicOverlay/AndroidManifest.xml
+++ b/fonts/FontLGSmartGothicOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.lgsmartgothic"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_lgsmartgothic_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="lgsmartgothic,lgsmartgothic-semi-bold,lgsmartgothic-bold" />
+    </application>
+</manifest>

--- a/fonts/FontLGSmartGothicOverlay/res/values/config.xml
+++ b/fonts/FontLGSmartGothicOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">lgsmartgothic</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">lgsmartgothic-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">lgsmartgothic</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">lgsmartgothic-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontLGSmartGothicOverlay/res/values/strings.xml
+++ b/fonts/FontLGSmartGothicOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font LGSmartGothic overlay -->
+    <string name="font_lgsmartgothic_overlay" translatable="false">LGSmartGothic</string>
+</resources>

--- a/fonts/FontLatoOverlay/Android.bp
+++ b/fonts/FontLatoOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontLatoOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontLato",
+}

--- a/fonts/FontLatoOverlay/AndroidManifest.xml
+++ b/fonts/FontLatoOverlay/AndroidManifest.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2020-2022, crDroid Android Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.lato"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1" />
+
+    <application
+        android:hasCode="false"
+        android:label="@string/font_lato_overlay">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="lato,lato-medium,lato-light,lato-semi-bold,lato-bold,lato-regular" />
+    </application>
+</manifest>

--- a/fonts/FontLatoOverlay/res/values/config.xml
+++ b/fonts/FontLatoOverlay/res/values/config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">lato</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">lato-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">lato-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">lato-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">lato-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">lato-regular</string>
+</resources>

--- a/fonts/FontLatoOverlay/res/values/strings.xml
+++ b/fonts/FontLatoOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Lato overlay -->
+    <string name="font_lato_overlay" translatable="false">Lato</string>
+</resources>

--- a/fonts/FontLinotteOverlay/Android.bp
+++ b/fonts/FontLinotteOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontLinotteOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontLinotte",
+}

--- a/fonts/FontLinotteOverlay/AndroidManifest.xml
+++ b/fonts/FontLinotteOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.linotte"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_linotte_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="linotte,linotte-semi-bold,linotte-bold,linotte-light,linotte-medium,linotte-regular" />
+    </application>
+</manifest>

--- a/fonts/FontLinotteOverlay/res/values/config.xml
+++ b/fonts/FontLinotteOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">linotte</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">linotte-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">linotte-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">linotte-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">linotte-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">linotte-regular</string>
+</resources>

--- a/fonts/FontLinotteOverlay/res/values/strings.xml
+++ b/fonts/FontLinotteOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Linotte overlay -->
+    <string name="font_linotte_overlay" translatable="false">Linotte</string>
+</resources>

--- a/fonts/FontNokiaPureOverlay/Android.bp
+++ b/fonts/FontNokiaPureOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontNokiaPureOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontNokiaPure",
+}

--- a/fonts/FontNokiaPureOverlay/AndroidManifest.xml
+++ b/fonts/FontNokiaPureOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.nokiapure"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_nokiapure_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="nokiapure,nokiapure-semi-bold,nokiapure-bold,nokiapure-light,nokiapure-medium" />
+    </application>
+</manifest>

--- a/fonts/FontNokiaPureOverlay/res/values/config.xml
+++ b/fonts/FontNokiaPureOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">nokiapure</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">nokiapure-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">nokiapure-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">nokiapure-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">nokiapure-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontNokiaPureOverlay/res/values/strings.xml
+++ b/fonts/FontNokiaPureOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Nokia Pure overlay -->
+    <string name="font_nokiapure_overlay" translatable="false">Nokia Pure</string>
+</resources>

--- a/fonts/FontNunitoOverlay/Android.bp
+++ b/fonts/FontNunitoOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontNunitoOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontNunito",
+}

--- a/fonts/FontNunitoOverlay/AndroidManifest.xml
+++ b/fonts/FontNunitoOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.nunito"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_nunito_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="nunito,nunito-semi-bold,nunito-bold,nunito-light,nunito-medium,nunito-regular" />
+    </application>
+</manifest>

--- a/fonts/FontNunitoOverlay/res/values/config.xml
+++ b/fonts/FontNunitoOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">nunito</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">nunito-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">nunito-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">nunito-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">nunito-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">nunito-regular</string>
+</resources>

--- a/fonts/FontNunitoOverlay/res/values/strings.xml
+++ b/fonts/FontNunitoOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Nunito overlay -->
+    <string name="font_nunito_overlay" translatable="false">Nunito</string>
+</resources>

--- a/fonts/FontOswaldOverlay/Android.bp
+++ b/fonts/FontOswaldOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontOswaldOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontOswald",
+}

--- a/fonts/FontOswaldOverlay/AndroidManifest.xml
+++ b/fonts/FontOswaldOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.oswald"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_oswald_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="oswald,oswald-semi-bold,oswald-bold,oswald-light,oswald-medium,oswald-regular" />
+    </application>
+</manifest>

--- a/fonts/FontOswaldOverlay/res/values/config.xml
+++ b/fonts/FontOswaldOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">oswald</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">oswald-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">oswald-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">oswald-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">oswald-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">oswald-regular</string>
+</resources>

--- a/fonts/FontOswaldOverlay/res/values/strings.xml
+++ b/fonts/FontOswaldOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Oswald overlay -->
+    <string name="font_oswald_overlay" translatable="false">Oswald</string>
+</resources>

--- a/fonts/FontQuandoOverlay/Android.bp
+++ b/fonts/FontQuandoOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontQuandoOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontQuando",
+}

--- a/fonts/FontQuandoOverlay/AndroidManifest.xml
+++ b/fonts/FontQuandoOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.quando"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_quando_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="quando,quando-semi-bold,quando-bold,quando-light,quando-medium" />
+    </application>
+</manifest>

--- a/fonts/FontQuandoOverlay/res/values/config.xml
+++ b/fonts/FontQuandoOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">quando</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">quando-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">quando-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">quando-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">quando-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontQuandoOverlay/res/values/strings.xml
+++ b/fonts/FontQuandoOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Quando overlay -->
+    <string name="font_quando_overlay" translatable="false">Quando</string>
+</resources>

--- a/fonts/FontRedressedOverlay/Android.bp
+++ b/fonts/FontRedressedOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontRedressedOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontRedressed",
+}

--- a/fonts/FontRedressedOverlay/AndroidManifest.xml
+++ b/fonts/FontRedressedOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.redressed"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_redressed_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="redressed,redressed-semi-bold,redressed-bold,redressed-light,redressed-medium" />
+    </application>
+</manifest>

--- a/fonts/FontRedressedOverlay/res/values/config.xml
+++ b/fonts/FontRedressedOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">redressed</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">redressed-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">redressed-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">redressed-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">redressed-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontRedressedOverlay/res/values/strings.xml
+++ b/fonts/FontRedressedOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font redressed overlay -->
+    <string name="font_redressed_overlay" translatable="false">redressed</string>
+</resources>

--- a/fonts/FontReemKufiOverlay/Android.bp
+++ b/fonts/FontReemKufiOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontReemKufiOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontReemKufi",
+}

--- a/fonts/FontReemKufiOverlay/AndroidManifest.xml
+++ b/fonts/FontReemKufiOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020, Xtended Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.reemkufi"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_reemkufi_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="reemkufi,reemkufi-semi-bold,reemkufi-bold,reemkufi-light,reemkufi-medium" />
+    </application>
+</manifest>

--- a/fonts/FontReemKufiOverlay/res/values/config.xml
+++ b/fonts/FontReemKufiOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020, Xtended Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">reemkufi</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">reemkufi-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">reemkufi-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">reemkufi-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">reemkufi-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontReemKufiOverlay/res/values/strings.xml
+++ b/fonts/FontReemKufiOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2020, Xtended Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font ReemKufi overlay -->
+    <string name="font_reemkufi_overlay" translatable="false">ReemKufi</string>
+</resources>

--- a/fonts/FontRobotoCondensedOverlay/Android.bp
+++ b/fonts/FontRobotoCondensedOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontRobotoCondensedOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontRobotoCondensed",
+}

--- a/fonts/FontRobotoCondensedOverlay/AndroidManifest.xml
+++ b/fonts/FontRobotoCondensedOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.robotocondensed"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_robotocondensed_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="robotocondensed,robotocondensed-semi-bold,robotocondensed-bold,robotocondensed-light,robotocondensed-medium" />
+    </application>
+</manifest>

--- a/fonts/FontRobotoCondensedOverlay/res/values/config.xml
+++ b/fonts/FontRobotoCondensedOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">robotocondensed</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">robotocondensed-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">robotocondensed-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">robotocondensed-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">robotocondensed-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontRobotoCondensedOverlay/res/values/strings.xml
+++ b/fonts/FontRobotoCondensedOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Roboto Condensed overlay -->
+    <string name="font_robotocondensed_overlay" translatable="false">Roboto Condensed</string>
+</resources>

--- a/fonts/FontRosemaryOverlay/Android.bp
+++ b/fonts/FontRosemaryOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontRosemaryOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontRosemary",
+}

--- a/fonts/FontRosemaryOverlay/AndroidManifest.xml
+++ b/fonts/FontRosemaryOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.rosemary"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_rosemary_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="rosemary,rosemary-semi-bold,rosemary-bold" />
+    </application>
+</manifest>

--- a/fonts/FontRosemaryOverlay/res/values/config.xml
+++ b/fonts/FontRosemaryOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">rosemary</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">rosemary-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">rosemary</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">rosemary-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontRosemaryOverlay/res/values/strings.xml
+++ b/fonts/FontRosemaryOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Rosemary overlay -->
+    <string name="font_rosemary_overlay" translatable="false">Rosemary</string>
+</resources>

--- a/fonts/FontRubikOverlay/Android.bp
+++ b/fonts/FontRubikOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontRubikOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontRubik",
+}

--- a/fonts/FontRubikOverlay/AndroidManifest.xml
+++ b/fonts/FontRubikOverlay/AndroidManifest.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2020-2022, crDroid Android Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.rubik"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1" />
+
+    <application
+        android:hasCode="false"
+        android:label="@string/font_rubik_overlay">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="rubik,rubik-medium,rubik-light,rubik-semi-bold,rubik-bold,rubik-regular" />
+    </application>
+</manifest>

--- a/fonts/FontRubikOverlay/res/values/config.xml
+++ b/fonts/FontRubikOverlay/res/values/config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (c) 2020-2022, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">rubik</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">rubik-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">rubik-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">rubik-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">rubik-light</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">rubik-regular</string>
+</resources>

--- a/fonts/FontRubikOverlay/res/values/strings.xml
+++ b/fonts/FontRubikOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2020-2022, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Rubik overlay -->
+    <string name="font_rubik_overlay" translatable="false">Rubik</string>
+</resources>

--- a/fonts/FontSamsungOneOverlay/Android.bp
+++ b/fonts/FontSamsungOneOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontSamsungOneOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontSamsungOne",
+}

--- a/fonts/FontSamsungOneOverlay/AndroidManifest.xml
+++ b/fonts/FontSamsungOneOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.samsungone"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_samsungone_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="samsungone,samsungone-semi-bold,samsungone-bold" />
+    </application>
+</manifest>

--- a/fonts/FontSamsungOneOverlay/res/values/config.xml
+++ b/fonts/FontSamsungOneOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">samsungone</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">samsungone-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">samsungone</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">samsungone-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontSamsungOneOverlay/res/values/strings.xml
+++ b/fonts/FontSamsungOneOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font SamsungOne overlay -->
+    <string name="font_samsungone_overlay" translatable="false">SamsungOne</string>
+</resources>

--- a/fonts/FontSonySketchOverlay/Android.bp
+++ b/fonts/FontSonySketchOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontSonySketchOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontSonySketch",
+}

--- a/fonts/FontSonySketchOverlay/AndroidManifest.xml
+++ b/fonts/FontSonySketchOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.sonysketch"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_sonysketch_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="sonysketch,sonysketch-semi-bold,sonysketch-bold" />
+    </application>
+</manifest>

--- a/fonts/FontSonySketchOverlay/res/values/config.xml
+++ b/fonts/FontSonySketchOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">sonysketch</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">sonysketch-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">sonysketch</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">sonysketch-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontSonySketchOverlay/res/values/strings.xml
+++ b/fonts/FontSonySketchOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font SonySketch overlay -->
+    <string name="font_sonysketch_overlay" translatable="false">SonySketch</string>
+</resources>

--- a/fonts/FontStoropiaOverlay/Android.bp
+++ b/fonts/FontStoropiaOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontStoropiaOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontStoropia",
+}

--- a/fonts/FontStoropiaOverlay/AndroidManifest.xml
+++ b/fonts/FontStoropiaOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.storopia"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_storopia_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="storopia,storopia-medium,storopia-semi-bold,storopia-bold" />
+    </application>
+</manifest>

--- a/fonts/FontStoropiaOverlay/res/values/config.xml
+++ b/fonts/FontStoropiaOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">storopia</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">storopia-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">storopia-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">storopia-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontStoropiaOverlay/res/values/strings.xml
+++ b/fonts/FontStoropiaOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font storopia overlay -->
+    <string name="font_storopia_overlay" translatable="false">Storopia</string>
+</resources>

--- a/fonts/FontSurferOverlay/Android.bp
+++ b/fonts/FontSurferOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontSurferOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontSurfer",
+}

--- a/fonts/FontSurferOverlay/AndroidManifest.xml
+++ b/fonts/FontSurferOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.surfer"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_surfer_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="surfer,surfer-semi-bold,surfer-bold" />
+    </application>
+</manifest>

--- a/fonts/FontSurferOverlay/res/values/config.xml
+++ b/fonts/FontSurferOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">surfer</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">surfer-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">surfer</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">surfer-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontSurferOverlay/res/values/strings.xml
+++ b/fonts/FontSurferOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font Surfer overlay -->
+    <string name="font_surfer_overlay" translatable="false">Surfer</string>
+</resources>

--- a/fonts/FontUbuntuOverlay/Android.bp
+++ b/fonts/FontUbuntuOverlay/Android.bp
@@ -1,0 +1,20 @@
+// Copyright (C) 2016-2022 crDroid Android Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+runtime_resource_overlay {
+    name: "FontUbuntuOverlay",
+    product_specific: true,
+    sdk_version: "current",
+    theme: "FontUbuntu",
+}

--- a/fonts/FontUbuntuOverlay/AndroidManifest.xml
+++ b/fonts/FontUbuntuOverlay/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.theme.font.ubuntu"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android"
+        android:category="android.theme.customization.font"
+        android:priority="1"/>
+
+    <application android:label="@string/font_ubuntu_overlay" android:hasCode="false">
+        <meta-data
+            android:name="android.theme.customization.REQUIRED_SYSTEM_FONTS"
+            android:value="ubuntu,ubuntu-medium,ubuntu-semi-bold,ubuntu-bold" />
+    </application>
+</manifest>

--- a/fonts/FontUbuntuOverlay/res/values/config.xml
+++ b/fonts/FontUbuntuOverlay/res/values/config.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Name of a font family to use for body text. -->
+    <string name="config_bodyFontFamily" translatable="false">ubuntu</string>
+    <!-- Name of a font family to use for medium body text. -->
+    <string name="config_bodyFontFamilyMedium" translatable="false">ubuntu-semi-bold</string>
+    <!-- Name of a font family to use for headlines. If empty, falls back to platform default -->
+    <string name="config_headlineFontFamily" translatable="false">ubuntu-medium</string>
+    <!-- Name of the font family used for system surfaces where the font should use medium weight -->
+    <string name="config_headlineFontFamilyMedium" translatable="false">ubuntu-bold</string>
+    <!-- Name of a font family to use as light font. For theming purpose. -->
+    <string name="config_lightFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+    <!-- Name of a font family to use as regular font. For theming purpose. -->
+    <string name="config_regularFontFamily" translatable="false">@string/config_bodyFontFamily</string>
+</resources>

--- a/fonts/FontUbuntuOverlay/res/values/strings.xml
+++ b/fonts/FontUbuntuOverlay/res/values/strings.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) 2019-2020, crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Headline / Body font ubuntu overlay -->
+    <string name="font_ubuntu_overlay" translatable="false">Ubuntu</string>
+</resources>

--- a/fonts/fonts_customization.xml
+++ b/fonts/fonts_customization.xml
@@ -379,4 +379,275 @@
     <alias name="op-sans-medium" to="op-sans" weight="500" />
     <alias name="op-sans-bold" to="op-sans" weight="700" />
     <alias name="op-sans-black" to="op-sans" weight="900" />
+
+<!-- additional fonts -->
+
+    <!-- Accuratist -->
+    <family customizationType="new-named-family" name="accuratist">
+        <font weight="400" style="normal">Accuratist.ttf</font>
+    </family>
+    <alias name="accuratist-light" to="accuratist" weight="300" />
+    <alias name="accuratist-medium" to="accuratist" weight="500" />
+    <alias name="accuratist-semi-bold" to="accuratist" weight="600" />
+    <alias name="accuratist-bold" to="accuratist" weight="700" />
+
+    <!-- Aclonica -->
+    <family customizationType="new-named-family" name="aclonica">
+        <font weight="300" style="normal">Aclonica.ttf</font>
+    </family>
+    <alias name="aclonica-semi-bold" to="aclonica" weight="600" />
+    <alias name="aclonica-bold" to="aclonica" weight="700" />
+
+    <!-- Amarante -->
+    <family customizationType="new-named-family" name="amarante">
+        <font weight="300" style="normal">Amarante.ttf</font>
+    </family>
+    <alias name="amarante-semi-bold" to="amarante" weight="600" />
+    <alias name="amarante-bold" to="amarante" weight="700" />
+
+    <!-- Bariol -->
+    <family customizationType="new-named-family" name="bariol">
+        <font weight="300" style="normal">Bariol-Regular.ttf</font>
+    </family>
+    <alias name="bariol-semi-bold" to="bariol" weight="600" />
+    <alias name="bariol-bold" to="bariol" weight="700" />
+
+    <!-- Cagliostro -->
+    <family customizationType="new-named-family" name="cagliostro">
+        <font weight="300" style="normal">Cagliostro-Regular.ttf</font>
+    </family>
+    <alias name="cagliostro-semi-bold" to="cagliostro" weight="600" />
+    <alias name="cagliostro-bold" to="cagliostro" weight="700" />
+
+    <!-- Cocon -->
+    <family customizationType="new-named-family" name="cocon">
+        <font weight="400" style="normal">Cocon.ttf</font>
+    </family>
+    <alias name="cocon-light" to="cocon" weight="300" />
+    <alias name="cocon-medium" to="cocon" weight="500" />
+    <alias name="cocon-semi-bold" to="cocon" weight="600" />
+    <alias name="cocon-bold" to="cocon" weight="700" />
+
+    <!-- Comfortaa -->
+    <family customizationType="new-named-family" name="comfortaa">
+        <font weight="400" style="normal">Comfortaa.ttf</font>
+    </family>
+    <alias name="comfortaa-medium" to="comfortaa" weight="500" />
+    <alias name="comfortaa-semi-bold" to="comfortaa" weight="600" />
+    <alias name="comfortaa-bold" to="comfortaa" weight="700" />
+
+    <!-- Comic Sans -->
+    <family customizationType="new-named-family" name="comicsans">
+        <font weight="400" style="normal">Comic_Sans.ttf</font>
+    </family>
+    <alias name="comicsans-semi-bold" to="comicsans" weight="600" />
+    <alias name="comicsans-bold" to="comicsans" weight="700" />
+
+    <!-- Coolstory -->
+    <family customizationType="new-named-family" name="coolstory">
+        <font weight="300" style="normal">Coolstory-Regular.ttf</font>
+    </family>
+    <alias name="coolstory-semi-bold" to="coolstory" weight="600" />
+    <alias name="coolstory-bold" to="coolstory" weight="700" />
+
+    <!-- Exotwo -->
+    <family customizationType="new-named-family" name="exotwo">
+        <font weight="400" style="normal">Exotwo.ttf</font>
+    </family>
+    <alias name="exotwo-medium" to="exotwo" weight="500" />
+    <alias name="exotwo-semi-bold" to="exotwo" weight="600" />
+    <alias name="exotwo-bold" to="exotwo" weight="700" />
+
+    <!-- Fifa 2018 -->
+    <family customizationType="new-named-family" name="fifa2018">
+        <font weight="400" style="normal">Fifa_2018.ttf</font>
+    </family>
+    <alias name="fifa2018-light" to="fifa2018" weight="300" />
+    <alias name="fifa2018-medium" to="fifa2018" weight="500" />
+    <alias name="fifa2018-semi-bold" to="fifa2018" weight="600" />
+    <alias name="fifa2018-bold" to="fifa2018" weight="700" />
+
+    <!-- GrandHotel -->
+    <family customizationType="new-named-family" name="grandhotel">
+        <font weight="400" style="normal">GrandHotel.ttf</font>
+    </family>
+    <alias name="grandhotel-light" to="grandhotel" weight="300" />
+    <alias name="grandhotel-medium" to="grandhotel" weight="500" />
+    <alias name="grandhotel-semi-bold" to="grandhotel" weight="600" />
+    <alias name="grandhotel-bold" to="grandhotel" weight="700" />
+
+    <!-- Lato -->
+    <family customizationType="new-named-family" name="lato">
+        <font weight="400" style="normal">Lato-Regular.ttf</font>
+        <font weight="400" style="italic">Lato-Italic.ttf</font>
+        <font weight="500" style="normal">Lato-Medium.ttf</font>
+        <font weight="500" style="italic">Lato-MediumItalic.ttf</font>
+        <font weight="700" style="normal">Lato-Bold.ttf</font>
+        <font weight="700" style="italic">Lato-BoldItalic.ttf</font>
+    </family>
+    <alias name="lato-light" to="lato" weight="300" />
+    <alias name="lato-regular" to="lato" weight="400" />
+    <alias name="lato-medium" to="lato" weight="500" />
+    <alias name="lato-semi-bold" to="lato" weight="600" />
+    <alias name="lato-bold" to="lato" weight="700" />
+
+    <!-- LGSmartGothic -->
+    <family customizationType="new-named-family" name="lgsmartgothic">
+        <font weight="300" style="normal">LGSmartGothic.ttf</font>
+    </family>
+    <alias name="lgsmartgothic-semi-bold" to="lgsmartgothic" weight="600" />
+    <alias name="lgsmartgothic-bold" to="lgsmartgothic" weight="700" />
+
+    <!-- Linotte -->
+    <family customizationType="new-named-family" name="linotte">
+        <font weight="300" style="normal">Linotte-Light.ttf</font>
+        <font weight="400" style="normal">Linotte-Regular.ttf</font>
+        <font weight="600" style="normal">Linotte-SemiBold.ttf</font>
+        <font weight="700" style="normal">Linotte-Bold.ttf</font>
+    </family>
+    <alias name="linotte-light" to="linotte" weight="300" />
+    <alias name="linotte-regular" to="linotte" weight="400" />
+    <alias name="linotte-medium" to="linotte" weight="500" />
+    <alias name="linotte-semi-bold" to="linotte" weight="600" />
+    <alias name="linotte-bold" to="linotte" weight="700" />
+
+    <!-- Nokia Pure -->
+    <family customizationType="new-named-family" name="nokiapure">
+        <font weight="400" style="normal">Nokia_Pure.ttf</font>
+    </family>
+    <alias name="nokiapure-light" to="nokiapure" weight="300" />
+    <alias name="nokiapure-medium" to="nokiapure" weight="500" />
+    <alias name="nokiapure-semi-bold" to="nokiapure" weight="600" />
+    <alias name="nokiapure-bold" to="nokiapure" weight="700" />
+
+    <!-- Nunito -->
+    <family customizationType="new-named-family" name="nunito">
+        <font weight="400" style="normal">Nunito-Regular.ttf</font>
+        <font weight="700" style="normal">Nunito-Bold.ttf</font>
+    </family>
+    <alias name="nunito-light" to="nunito" weight="300" />
+    <alias name="nunito-regular" to="nunito" weight="400" />
+    <alias name="nunito-medium" to="nunito" weight="500" />
+    <alias name="nunito-semi-bold" to="nunito" weight="600" />
+    <alias name="nunito-bold" to="nunito" weight="700" />
+
+    <!-- Oswald -->
+    <family customizationType="new-named-family" name="oswald">
+        <font weight="300" style="normal">Oswald-Light.ttf</font>
+        <font weight="300" style="italic">Oswald-LightItalic.ttf</font>
+        <font weight="400" style="normal">Oswald-Regular.ttf</font>
+        <font weight="400" style="italic">Oswald-RegularItalic.ttf</font>
+        <font weight="500" style="normal">Oswald-Medium.ttf</font>
+        <font weight="500" style="italic">Oswald-MediumItalic.ttf</font>
+        <font weight="700" style="normal">Oswald-Bold.ttf</font>
+        <font weight="700" style="italic">Oswald-BoldItalic.ttf</font>
+    </family>
+    <alias name="oswald-light" to="oswald" weight="300" />
+    <alias name="oswald-regular" to="oswald" weight="400" />
+    <alias name="oswald-medium" to="oswald" weight="500" />
+    <alias name="oswald-semi-bold" to="oswald" weight="600" />
+    <alias name="oswald-bold" to="oswald" weight="700" />
+
+    <!-- Quando -->
+    <family customizationType="new-named-family" name="quando">
+        <font weight="400" style="normal">Quando.ttf</font>
+    </family>
+    <alias name="quando-light" to="quando" weight="300" />
+    <alias name="quando-medium" to="quando" weight="500" />
+    <alias name="quando-semi-bold" to="quando" weight="600" />
+    <alias name="quando-bold" to="quando" weight="700" />
+
+    <!-- Redressed -->
+    <family customizationType="new-named-family" name="redressed">
+        <font weight="400" style="normal">Redressed.ttf</font>
+    </family>
+    <alias name="redressed-light" to="redressed" weight="300" />
+    <alias name="redressed-medium" to="redressed" weight="500" />
+    <alias name="redressed-semi-bold" to="redressed" weight="600" />
+    <alias name="redressed-bold" to="redressed" weight="700" />
+
+    <!-- ReemKufi -->
+    <family customizationType="new-named-family" name="reemkufi">
+        <font weight="400" style="normal">ReemKufi.ttf</font>
+    </family>
+    <alias name="reemkufi-light" to="reemkufi" weight="300" />
+    <alias name="reemkufi-medium" to="reemkufi" weight="500" />
+    <alias name="reemkufi-semi-bold" to="reemkufi" weight="600" />
+    <alias name="reemkufi-bold" to="reemkufi" weight="700" />
+
+    <!-- Roboto Condensed -->
+    <family customizationType="new-named-family" name="robotocondensed">
+        <font weight="300" style="normal">RobotoCondensed-Light.ttf</font>
+        <font weight="300" style="italic">RobotoCondensed-LightItalic.ttf</font>
+        <font weight="400" style="normal">RobotoCondensed-Regular.ttf</font>
+        <font weight="400" style="italic">RobotoCondensed-Italic.ttf</font>
+        <font weight="500" style="normal">RobotoCondensed-Medium.ttf</font>
+        <font weight="500" style="italic">RobotoCondensed-MediumItalic.ttf</font>
+        <font weight="700" style="normal">RobotoCondensed-Bold.ttf</font>
+        <font weight="700" style="italic">RobotoCondensed-BoldItalic.ttf</font>
+    </family>
+    <alias name="robotocondensed-light" to="robotocondensed" weight="300" />
+    <alias name="robotocondensed-medium" to="robotocondensed" weight="500" />
+    <alias name="robotocondensed-semi-bold" to="robotocondensed" weight="600" />
+    <alias name="robotocondensed-bold" to="robotocondensed" weight="700" />
+
+    <!-- Rosemary -->
+    <family customizationType="new-named-family" name="rosemary">
+        <font weight="300" style="normal">Rosemary-Regular.ttf</font>
+    </family>
+    <alias name="rosemary-semi-bold" to="rosemary" weight="600" />
+    <alias name="rosemary-bold" to="rosemary" weight="700" />
+
+    <!-- Rubik -->
+    <family customizationType="new-named-family" name="rubik">
+        <font weight="400" style="normal">Rubik-Regular.ttf</font>
+        <font weight="400" style="italic">Rubik-Italic.ttf</font>
+        <font weight="500" style="normal">Rubik-Medium.ttf</font>
+        <font weight="500" style="italic">Rubik-MediumItalic.ttf</font>
+        <font weight="700" style="normal">Rubik-Bold.ttf</font>
+        <font weight="700" style="italic">Rubik-BoldItalic.ttf</font>
+    </family>
+    <alias name="rubik-light" to="rubik" weight="300" />
+    <alias name="rubik-regular" to="rubik" weight="400" />
+    <alias name="rubik-medium" to="rubik" weight="500" />
+    <alias name="rubik-semi-bold" to="rubik" weight="600" />
+    <alias name="rubik-bold" to="rubik" weight="700" />
+
+    <!-- SamsungOne -->
+    <family customizationType="new-named-family" name="samsungone">
+        <font weight="400" style="normal">SamsungOne-400.ttf</font>
+        <font weight="700" style="normal">SamsungOne-700.ttf</font>
+    </family>
+    <alias name="samsungone-semi-bold" to="samsungone" weight="600" />
+    <alias name="samsungone-bold" to="samsungone" weight="700" />
+
+    <!-- SonySketch -->
+    <family customizationType="new-named-family" name="sonysketch">
+        <font weight="300" style="normal">SonySketch.ttf</font>
+    </family>
+    <alias name="sonysketch-semi-bold" to="sonysketch" weight="600" />
+    <alias name="sonysketch-bold" to="sonysketch" weight="700" />
+
+    <!-- Storopia -->
+    <family customizationType="new-named-family" name="storopia">
+        <font weight="400" style="normal">Storopia.ttf</font>
+    </family>
+    <alias name="storopia-medium" to="storopia" weight="500" />
+    <alias name="storopia-semi-bold" to="storopia" weight="600" />
+    <alias name="storopia-bold" to="storopia" weight="700" />
+
+    <!-- Surfer -->
+    <family customizationType="new-named-family" name="surfer">
+        <font weight="300" style="normal">Surfer.ttf</font>
+    </family>
+    <alias name="surfer-semi-bold" to="surfer" weight="600" />
+    <alias name="surfer-bold" to="surfer" weight="700" />
+
+    <!-- Ubuntu -->
+    <family customizationType="new-named-family" name="ubuntu">
+        <font weight="400" style="normal">Ubuntu.ttf</font>
+    </family>
+    <alias name="ubuntu-medium" to="ubuntu" weight="500" />
+    <alias name="ubuntu-semi-bold" to="ubuntu" weight="600" />
+    <alias name="ubuntu-bold" to="ubuntu" weight="700" />
 </fonts-modification>


### PR DESCRIPTION
Raven uses a prebuilt custom kernel and this is a requirement. It was there previously but got nuked during the previous commit. Shouldn't have any breakage with this, it simply wraps the existing code in a if statement that only is run if NO_KERNEL_OVERRIDE is NOT SET