### PR TITLE
spark: Show Android version as 12L [2/2]

### DIFF
--- a/build/core/main_version.mk
+++ b/build/core/main_version.mk
@@ -13,3 +13,7 @@ ADDITIONAL_SYSTEM_PROPERTIES += \
     ro.spark.fingerprint=$(ROM_FINGERPRINT) \
     ro.spark.version=$(SPARK_VERSION) \
     ro.modversion=$(SPARK_VERSION)
+
+# SparkOS Android 12L Specific Props
+ADDITIONAL_SYSTEM_PROPERTIES += \
+    ro.spark.settings.android_version=12L


### PR DESCRIPTION
* Android 12 & 12L, Both Show Platform version as "12", while 12L is not a QPR release , its a Android Bump
  ( Android 12 = VNDK31, Android 12.1/12L = VNDK 32 ), Even Google released the newer tags with android-12.1.0_r1 ,
   not with android-12.0.0 branding [1], Some end users do not know if they're running Android 12 or 12L, this's because
   Android Version Being displayed as "12" on both 12 & 12L, Even Google Docs [2] refer the newer Android Version as 12L,
   I've no idea why they didnt care to bump it here, hence refactor PLATFORM_VERSION_LAST_STABLE to 12L

[1] - https://android.googlesource.com/platform/manifest/+/refs/tags/android-12.1.0_r1
[2] - https://developer.android.com/about/versions/12/12L/summary
Signed-off-by: Aryan Sinha <sinha.aryan03@gmail.com>