### PR TITLE
packages: build GmsCompat by default

### DIFF
--- a/config/packages.mk
+++ b/config/packages.mk
@@ -7,6 +7,10 @@ PRODUCT_PACKAGES += \
     wellbeingconf \
     googleconf
 
+# GMS
+PRODUCT_PACKAGES += \
+    GmsCompat
+
 ifneq ($(TARGET_NO_PREBUILT_CAMERA),true)
 PRODUCT_PACKAGES += \
     Camera


### PR DESCRIPTION
* I don't understand the aspects behind it all but with devices that
use the Generic System Image standard practices (Google Pixel 6 Pro),
then there are tight restrictions on artifact path requirements. You
overcome this by adding the offending files to an "allowlist" to
supress the error. But for some reason when an app that has files that
violate the requirements and need to add it files to the allowlist and
calling the compile of the offending package from the "build" repo the
artifact paths allowlist is not honored and the compile fails just move
the call to build GmsCompat to vendor/spark. It has no regressions and
makes more logical sense

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>