### PR TITLE
device_config: Disable always screen on

### DIFF
--- a/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
+++ b/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (C) 2020 The Proton AOSP Project
+                  2022 The LineageOS Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -99,5 +100,8 @@
         <item>device_personalization_services/Logging__enable_aiai_clearcut_logging=false</item>
         <item>device_personalization_services/NotificationAssistant__enable_service=false</item>
         <item>device_personalization_services/VisualCortex__enable=false</item>
+
+        <!-- Disable always screen on -->
+        <item>attention_manager_service/keep_screen_on_enabled=false</item>
     </string-array>
 </resources>


### PR DESCRIPTION
- Some devices are keeping screen on and not turning off. Reported in some pixels and asus

Issue: https://www.reddit.com/r/LineageOS/comments/uw5d8p/screen_timeout_issue_on_pixels_on_android_12/ https://gitlab.com/LineageOS/issues/android/-/issues/4798

Change-Id: I1e2471928b47387f7e40adb81d3457bb58cc2755