### PR TITLE
config: Guard call to build Face Unlock properly

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -2,7 +2,6 @@
 $(call inherit-product-if-exists, vendor/extra/product.mk)
 $(call inherit-product, vendor/spark/config/bootanimation.mk)
 $(call inherit-product, vendor/addons/config.mk)
-$(call inherit-product, external/faceunlock/config.mk)
 $(call inherit-product-if-exists, vendor/spark/audio/audio.mk)
 
 PRODUCT_BRAND ?= Spark
@@ -169,6 +168,12 @@ ifeq ($(WITH_GAPPS), true)
 # GApps
 $(call inherit-product, vendor/gms/products/gms.mk)
 include vendor/gms/products/board.mk
+endif
+
+# Faceunlock
+TARGET_FACE_UNLOCK_SUPPORTED ?= true
+ifeq ($(TARGET_FACE_UNLOCK_SUPPORTED),true)
+$(call inherit-product-if-exists, external/faceunlock/config.mk)
 endif
 
 # Enforce privapp-permissions whitelist


### PR DESCRIPTION
* Some devices like pantah (Pixel 7/7 Pro) utilize a different implementation then what most devices use and prior to this change, the config.mk was still being inherited which in the Pixel 7s case breaks the function completely. With this change there is no functional different to the device tree. It will check if the if the build flag is not false then the code block is executed. If it finds the face unlock build flag empty set it to "true".